### PR TITLE
feat: Implement basic context management for Electron UI

### DIFF
--- a/jarules_agent/connectors/base_llm_connector.py
+++ b/jarules_agent/connectors/base_llm_connector.py
@@ -26,17 +26,18 @@ class BaseLLMConnector(ABC):
         self.model_name = model_name
         # Allow subclasses to use additional configuration via kwargs
         # For example, api_key, base_url, etc.
-        self._config = kwargs 
+        self._config = kwargs
         super().__init__()
 
     @abstractmethod
-    def generate_code(self, user_prompt: str, system_instruction: Optional[str] = None, **kwargs: Any) -> Optional[str]:
+    def generate_code(self, user_prompt: str, system_instruction: Optional[str] = None, history: Optional[list[dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
         """
         Generates code based on a user prompt and optional system instructions.
 
         Args:
             user_prompt: The user's direct request for code generation.
             system_instruction: Optional. Guiding instruction for the model's behavior or output format.
+            history: Optional. A list of dictionaries representing the conversation history.
             **kwargs: Additional provider-specific parameters for generation.
 
         Returns:
@@ -48,13 +49,14 @@ class BaseLLMConnector(ABC):
         pass
 
     @abstractmethod
-    def explain_code(self, code_snippet: str, system_instruction: Optional[str] = None, **kwargs: Any) -> Optional[str]:
+    def explain_code(self, code_snippet: str, system_instruction: Optional[str] = None, history: Optional[list[dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
         """
         Explains a given code snippet.
 
         Args:
             code_snippet: The string containing the code to be explained.
             system_instruction: Optional. Guiding instruction for the model's explanation.
+            history: Optional. A list of dictionaries representing the conversation history.
             **kwargs: Additional provider-specific parameters.
 
         Returns:
@@ -66,7 +68,7 @@ class BaseLLMConnector(ABC):
         pass
 
     @abstractmethod
-    def suggest_code_modification(self, code_snippet: str, issue_description: str, system_instruction: Optional[str] = None, **kwargs: Any) -> Optional[str]:
+    def suggest_code_modification(self, code_snippet: str, issue_description: str, system_instruction: Optional[str] = None, history: Optional[list[dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
         """
         Suggests modifications to a given code snippet based on an issue description.
 
@@ -74,11 +76,12 @@ class BaseLLMConnector(ABC):
             code_snippet: The string containing the code to be modified.
             issue_description: A natural language description of the desired modification or fix.
             system_instruction: Optional. Guiding instruction for the model.
+            history: Optional. A list of dictionaries representing the conversation history.
             **kwargs: Additional provider-specific parameters.
 
         Returns:
             The suggested modified code as a string, or None if generation fails/is blocked.
-            
+
         Raises:
             LLMConnectorError: If an error occurs during code modification suggestion.
         """

--- a/jarules_agent/connectors/ollama_connector.py
+++ b/jarules_agent/connectors/ollama_connector.py
@@ -32,24 +32,24 @@ class OllamaConnector(BaseLLMConnector):
                                                              (e.g., temperature, top_p).
                     - 'request_timeout' (int, optional): Timeout for HTTP requests in seconds.
         """
-        super().__init__(config)
-        self.api_base_url = config.get("api_base_url", "http://localhost:11434")
+        super().__init__(model_name=config.get("model_name", "llama3"), **config) # Pass model_name and other config to BaseLLMConnector
+        self.api_base_url = self._config.get("api_base_url", "http://localhost:11434")
         # Ensure base URL doesn't end with a slash to simplify joining with /api/generate etc.
         if self.api_base_url.endswith('/'):
             self.api_base_url = self.api_base_url[:-1]
 
-        self.model_name = config.get("model_name", "llama3") # Renamed from default_model for clarity
-        self.default_system_prompt = config.get("default_system_prompt", None)
-        self.generation_params = config.get("generation_params", {})
-        request_timeout = config.get("request_timeout", 30) # Default timeout 30 seconds
+        # self.model_name is already set by BaseLLMConnector
+        self.default_system_prompt = self._config.get("default_system_prompt", None)
+        self.generation_params = self._config.get("generation_params", {})
+        request_timeout = self._config.get("request_timeout", 30) # Default timeout 30 seconds
 
         self.client = httpx.AsyncClient(base_url=self.api_base_url, timeout=request_timeout)
         logger.info(
             f"OllamaConnector initialized with base_url: {self.api_base_url}, "
-            f"model: {self.model_name}, timeout: {request_timeout}"
+            f"model: {self.model_name}, timeout: {request_timeout}" # self.model_name from BaseLLMConnector
         )
-        if self.default_system_prompt:
-            logger.info(f"Default system prompt: {self.default_system_prompt[:100]}...")
+        if self.default_system_prompt: # self.default_system_prompt from self._config
+            logger.info(f"Default system prompt: {(self.default_system_prompt or '')[:100]}...")
         if self.generation_params:
             logger.info(f"Default generation parameters: {self.generation_params}")
 
@@ -104,153 +104,202 @@ class OllamaConnector(BaseLLMConnector):
             logger.error(f"An unexpected error occurred during Ollama availability check: {e}")
             return False
 
-    async def generate_code(self, user_prompt: str, system_instruction: str = None, context: str = "") -> str:
-        """
-        Generates code based on the given prompt and context using Ollama.
-        (Placeholder implementation)
-        """
-        logger.info(f"generate_code called with prompt: {prompt[:50]}...")
-        # Actual implementation will involve making an HTTP request to Ollama
-        """
-        Generates code based on the given prompt and context using Ollama.
-        (Implementation for stream: false)
-        """
-        logger.info(f"generate_code called with user_prompt: {user_prompt[:50]}...")
+from typing import Optional, List, Dict, Any # Added Optional, List, Dict, Any
 
-        current_system_prompt = system_instruction if system_instruction is not None else self.default_system_prompt
+# Define a custom exception for Ollama API errors
+class OllamaApiError(Exception): # Should inherit from LLMConnectorError or a base Exception from base_llm_connector
+    """Custom exception for Ollama API errors."""
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
 
-        # Constructing the full prompt or payload
-        # Context can be prepended to the user_prompt or handled in a more structured way if the model supports it.
-        full_prompt = f"{context}\n\nUser: {user_prompt}" if context else user_prompt
+class OllamaConnector(BaseLLMConnector): # BaseLLMConnector now expects model_name as first arg
+    """
+    Connector for interacting with local LLMs through the Ollama API.
+    """
 
+    def __init__(self, model_name: Optional[str] = None, **kwargs: Any): # Updated signature
+        """
+        Initializes the OllamaConnector.
+
+        Args:
+            model_name: Optional. The default model to use (e.g., "llama3").
+            **kwargs: Configuration parameters for Ollama.
+                      Expected keys in kwargs:
+                      - 'api_base_url' (str): The base URL for the Ollama API.
+                                              Defaults to "http://localhost:11434".
+                      - 'default_system_prompt' (str, optional): Default system prompt.
+                      - 'generation_params' (dict, optional): Default generation parameters
+                                                               (e.g., temperature, top_p).
+                      - 'request_timeout' (int, optional): Timeout for HTTP requests in seconds.
+                                                           Defaults to 30.
+        """
+        effective_model_name = model_name or kwargs.get("model_name") or "llama3" # Prioritize explicit, then in kwargs, then default
+        super().__init__(model_name=effective_model_name, **kwargs) # Pass model_name and other config to BaseLLMConnector
+
+        self.api_base_url = self._config.get("api_base_url", "http://localhost:11434")
+        if self.api_base_url.endswith('/'):
+            self.api_base_url = self.api_base_url[:-1]
+
+        self.default_system_prompt = self._config.get("default_system_prompt")
+        self.generation_params = self._config.get("generation_params", {})
+        request_timeout = self._config.get("request_timeout", 30)
+
+        self.client = httpx.AsyncClient(base_url=self.api_base_url, timeout=request_timeout)
+        logger.info(
+            f"OllamaConnector initialized with base_url: {self.api_base_url}, "
+            f"model: {self.model_name}, timeout: {request_timeout}"
+        )
+        if self.default_system_prompt:
+            logger.info(f"Default system prompt: {(self.default_system_prompt or '')[:100]}...")
+        if self.generation_params:
+            logger.info(f"Default generation parameters: {self.generation_params}")
+
+    async def _make_request(self, endpoint: str, method_payload: dict, history: Optional[List[Dict[str, str]]] = None) -> str:
+        """
+        Helper function to make a request to Ollama API.
+        Handles /api/generate and /api/chat based on history.
+        """
         payload = {
             "model": self.model_name,
-            "prompt": full_prompt,
-            "stream": False, # For simplicity in this version
-            # "options": self.generation_params, # Pass through other params like temperature
+            "stream": False, # For simplicity
+            # "options" will be merged from self.generation_params and method_payload.options if any
         }
-        if current_system_prompt:
-            payload["system"] = current_system_prompt
 
-        # Merge default generation_params with any specific ones if needed later
-        if self.generation_params:
-            payload.setdefault("options", {}).update(self.generation_params)
+        # Merge system prompt
+        if method_payload.get("system"):
+            payload["system"] = method_payload["system"]
 
+        # Merge generation options
+        options = self.generation_params.copy() # Start with class defaults
+        if method_payload.get("options"):
+            options.update(method_payload["options"]) # Override with method-specific options
+        if options:
+            payload["options"] = options
+
+        # Determine if using /api/chat or /api/generate based on history
+        # Ollama's /api/chat expects "messages": [{"role": "user/assistant", "content": "..."}]
+        # /api/generate expects "prompt": "...", "system": "..." (optional), "context": [] (optional for prior turns)
+
+        actual_endpoint = endpoint # default to /api/generate or whatever was passed
+
+        if history: # Use /api/chat if history is provided
+            actual_endpoint = "/api/chat"
+            messages = []
+            for item in history:
+                # Transform history keys: "text" or "content" to "content"
+                content = item.get("text") or item.get("content")
+                if not content: continue # Skip if no content
+
+                # Ensure role is "user" or "assistant". Default to "user" if unknown.
+                role = item.get("role", "user").lower()
+                if role not in ["user", "assistant", "system"]: # Ollama chat supports system role in messages
+                    logger.warning(f"Unknown role '{role}' in history, defaulting to 'user'.")
+                    role = "user"
+                messages.append({"role": role, "content": content})
+
+            # Add the current user prompt to messages
+            if method_payload.get("prompt"): # For chat, the "prompt" is the last user message
+                 messages.append({"role": "user", "content": method_payload["prompt"]})
+
+            payload["messages"] = messages
+            # Remove "prompt" and "system" from payload if using /api/chat, as they are in "messages"
+            payload.pop("prompt", None)
+            # payload.pop("system", None) # System prompt can be a top-level element for /api/chat too
+            if payload.get("system") and any(m["role"] == "system" for m in messages):
+                logger.warning("System prompt provided both at top-level and in messages for /api/chat. Top-level might be preferred by Ollama.")
+
+        else: # No history, use /api/generate (or the original endpoint)
+            if "prompt" in method_payload:
+                payload["prompt"] = method_payload["prompt"]
+            # "context" for /api/generate is for passing back the context from previous /api/generate calls,
+            # not the same as conversational history. For now, we are not managing this low-level context.
+
+        logger.debug(f"Ollama request to {actual_endpoint}. Payload: {json.dumps(payload, indent=2)}")
 
         try:
-            response = await self.client.post("/api/generate", json=payload)
+            response = await self.client.post(actual_endpoint, json=payload)
             response.raise_for_status()
-
             response_data = response.json()
 
-            # The 'response' field contains the generated text.
-            # Other fields include 'created_at', 'model', 'done', 'total_duration', etc.
-            generated_text = response_data.get("response", "")
-            if not generated_text and response_data.get("done", False):
-                logger.warning("Ollama response was empty but request was marked as done.")
+            if actual_endpoint == "/api/chat":
+                # For /api/chat, the response structure is like:
+                # { "model": "...", "created_at": "...", "message": { "role": "assistant", "content": "..." }, "done": true }
+                generated_text = response_data.get("message", {}).get("content", "")
+            else: # /api/generate
+                generated_text = response_data.get("response", "")
 
-            logger.info(f"Successfully received response from Ollama for generate_code. Length: {len(generated_text)}")
+            if not generated_text and response_data.get("done", False):
+                logger.warning(f"Ollama response was empty from {actual_endpoint} but request was marked as done.")
+
+            logger.info(f"Successfully received response from Ollama {actual_endpoint}. Length: {len(generated_text)}")
             return generated_text.strip()
 
         except httpx.RequestError as e:
-            logger.error(f"Error connecting to Ollama API for generate_code: {e}")
-            raise OllamaApiError(f"Connection to Ollama failed: {e}", status_code=None) from e
+            logger.error(f"Error connecting to Ollama API for {actual_endpoint}: {e}")
+            raise OllamaApiError(f"Connection to Ollama failed: {e}") from e
         except httpx.HTTPStatusError as e:
-            logger.error(f"Ollama API request failed for generate_code: {e.response.status_code} - {e.response.text[:200]}")
+            logger.error(f"Ollama API request failed for {actual_endpoint}: {e.response.status_code} - {e.response.text[:200]}")
             raise OllamaApiError(f"Ollama API error: {e.response.status_code} - {e.response.text[:200]}", status_code=e.response.status_code) from e
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON response from Ollama generate_code: {e}")
-            raise OllamaApiError(f"Invalid JSON response from Ollama: {e}", status_code=None) from e
+            logger.error(f"Failed to parse JSON response from Ollama {actual_endpoint}: {e}")
+            raise OllamaApiError(f"Invalid JSON response from Ollama: {e}") from e
         except Exception as e:
-            logger.error(f"An unexpected error occurred during Ollama generate_code: {e}")
-            raise OllamaApiError(f"An unexpected error occurred: {e}", status_code=None) from e
+            logger.error(f"An unexpected error occurred during Ollama {actual_endpoint}: {e}")
+            raise OllamaApiError(f"An unexpected error occurred: {e}") from e
 
 
-    async def explain_code(self, code_snippet: str, system_instruction: str = None, context: str = "") -> str:
-        """
-        Explains the given code snippet using Ollama.
-        """
+    async def generate_code(self, user_prompt: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
+        logger.info(f"generate_code called with user_prompt: {user_prompt[:50]}...")
+        current_system_prompt = system_instruction if system_instruction is not None else self.default_system_prompt
+
+        # The 'context' parameter from the old signature is not used here.
+        # If context is needed, it should be part of the user_prompt or history.
+
+        payload = {
+            "prompt": user_prompt, # This will be the main content for /api/generate or last message for /api/chat
+            "system": current_system_prompt,
+            "options": kwargs.get("options", {}) # Allow overriding generation_params via kwargs
+        }
+        return await self._make_request("/api/generate", payload, history=history)
+
+
+    async def explain_code(self, code_snippet: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
         logger.info(f"explain_code called for code snippet: {code_snippet[:50]}...")
 
-        prompt = f"{context}\n\nPlease explain the following code snippet:\n```\n{code_snippet}\n```" if context \
-            else f"Please explain the following code snippet:\n```\n{code_snippet}\n```"
+        prompt = f"Please explain the following code snippet:\n```\n{code_snippet}\n```"
 
-        # Use a default system prompt if none provided, or tailor one for explanation
         current_system_prompt = system_instruction
         if current_system_prompt is None:
              current_system_prompt = self.default_system_prompt if self.default_system_prompt else "You are an expert code explainer. Provide clear and concise explanations."
 
         payload = {
-            "model": self.model_name,
             "prompt": prompt,
             "system": current_system_prompt,
-            "stream": False,
+            "options": kwargs.get("options", {})
         }
-        if self.generation_params:
-            payload.setdefault("options", {}).update(self.generation_params)
-
-        try:
-            response = await self.client.post("/api/generate", json=payload)
-            response.raise_for_status()
-            response_data = response.json()
-            explanation = response_data.get("response", "").strip()
-            logger.info(f"Successfully received explanation from Ollama. Length: {len(explanation)}")
-            return explanation
-        except httpx.RequestError as e:
-            logger.error(f"Error connecting to Ollama API for explain_code: {e}")
-            raise OllamaApiError(f"Connection to Ollama failed: {e}", status_code=None) from e
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Ollama API request failed for explain_code: {e.response.status_code} - {e.response.text[:200]}")
-            raise OllamaApiError(f"Ollama API error: {e.response.status_code} - {e.response.text[:200]}", status_code=e.response.status_code) from e
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON response from Ollama explain_code: {e}")
-            raise OllamaApiError(f"Invalid JSON response from Ollama: {e}", status_code=None) from e
-        except Exception as e:
-            logger.error(f"An unexpected error occurred during Ollama explain_code: {e}")
-            raise OllamaApiError(f"An unexpected error occurred: {e}", status_code=None) from e
+        return await self._make_request("/api/generate", payload, history=history)
 
 
-    async def suggest_code_modification(self, code_snippet: str, instruction: str, system_instruction: str = None, context: str = "") -> str:
-        """
-        Suggests modifications to the code snippet based on the instruction using Ollama.
-        """
-        logger.info(f"suggest_code_modification called for code: {code_snippet[:50]} with instruction: {instruction}")
+    async def suggest_code_modification(self, code_snippet: str, issue_description: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
+        logger.info(f"suggest_code_modification called for code: {code_snippet[:50]} with issue: {issue_description[:50]}")
 
-        prompt = f"{context}\n\nCode snippet:\n```\n{code_snippet}\n```\n\nInstruction for modification: {instruction}\n\nPlease provide the modified code snippet or explain the necessary changes." if context \
-            else f"Code snippet:\n```\n{code_snippet}\n```\n\nInstruction for modification: {instruction}\n\nPlease provide the modified code snippet or explain the necessary changes."
+        prompt = (
+            f"Code snippet:\n```\n{code_snippet}\n```\n\n"
+            f"Issue/Request for modification: {issue_description}\n\n"
+            "Please provide the modified code snippet."
+        )
 
         current_system_prompt = system_instruction
         if current_system_prompt is None:
             current_system_prompt = self.default_system_prompt if self.default_system_prompt else "You are an expert code modification assistant. Provide only the modified code or a clear description of changes if code modification isn't directly possible."
 
         payload = {
-            "model": self.model_name,
             "prompt": prompt,
             "system": current_system_prompt,
-            "stream": False,
+            "options": kwargs.get("options", {})
         }
-        if self.generation_params:
-            payload.setdefault("options", {}).update(self.generation_params)
-
-        try:
-            response = await self.client.post("/api/generate", json=payload)
-            response.raise_for_status()
-            response_data = response.json()
-            suggestion = response_data.get("response", "").strip()
-            logger.info(f"Successfully received code modification suggestion from Ollama. Length: {len(suggestion)}")
-            return suggestion
-        except httpx.RequestError as e:
-            logger.error(f"Error connecting to Ollama API for suggest_code_modification: {e}")
-            raise OllamaApiError(f"Connection to Ollama failed: {e}", status_code=None) from e
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Ollama API request failed for suggest_code_modification: {e.response.status_code} - {e.response.text[:200]}")
-            raise OllamaApiError(f"Ollama API error: {e.response.status_code} - {e.response.text[:200]}", status_code=e.response.status_code) from e
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON response from Ollama suggest_code_modification: {e}")
-            raise OllamaApiError(f"Invalid JSON response from Ollama: {e}", status_code=None) from e
-        except Exception as e:
-            logger.error(f"An unexpected error occurred during Ollama suggest_code_modification: {e}")
-            raise OllamaApiError(f"An unexpected error occurred: {e}", status_code=None) from e
+        return await self._make_request("/api/generate", payload, history=history)
 
     async def close(self):
         """

--- a/jarules_agent/connectors/openrouter_connector.py
+++ b/jarules_agent/connectors/openrouter_connector.py
@@ -2,15 +2,16 @@ import logging
 import os
 import httpx
 
-from jarules_agent.connectors.base_llm_connector import BaseLLMConnector
+from typing import Optional, List, Dict, Any # Added Optional, List, Dict, Any
+from jarules_agent.connectors.base_llm_connector import BaseLLMConnector, LLMConnectorError
 
 logger = logging.getLogger(__name__)
 
 # Define a custom exception for OpenRouter API errors
-class OpenRouterApiError(Exception):
+class OpenRouterApiError(LLMConnectorError): # Inherit from LLMConnectorError
     """Custom exception for OpenRouter API errors."""
-    def __init__(self, message, status_code=None):
-        super().__init__(message)
+    def __init__(self, message, status_code=None, underlying_exception: Optional[Exception] = None):
+        super().__init__(message, underlying_exception=underlying_exception)
         self.status_code = status_code
 
 class OpenRouterConnector(BaseLLMConnector):
@@ -21,37 +22,39 @@ class OpenRouterConnector(BaseLLMConnector):
     DEFAULT_API_BASE_URL = "https://openrouter.ai/api/v1"
     DEFAULT_MODEL_NAME = "gryphe/mythomax-l2-13b" # A free model for default
 
-    def __init__(self, config: dict):
+    def __init__(self, model_name: Optional[str] = None, **kwargs: Any): # Updated signature
         """
         Initializes the OpenRouterConnector.
 
         Args:
-            config: A dictionary containing configuration parameters.
-                    Expected keys:
-                    - 'api_key_env_var' (str): Name of the environment variable holding the API key.
-                    - 'model_name' (str, optional): Default model to use (e.g., "openai/gpt-4o").
-                    - 'api_base_url' (str, optional): Base URL for the OpenRouter API.
-                    - 'default_system_prompt' (str, optional): Default system prompt.
-                    - 'generation_params' (dict, optional): Default generation parameters.
-                    - 'request_timeout' (int, optional): Timeout for HTTP requests.
-                    - 'http_referer' (str, optional): HTTP Referer header, often your site URL.
+            model_name: Optional. The default model to use (e.g., "openai/gpt-4o").
+            **kwargs: Configuration parameters.
+                      Expected keys in kwargs:
+                      - 'api_key_env_var' (str): Name of the environment variable holding the API key.
+                                                 Defaults to "OPENROUTER_API_KEY".
+                      - 'api_base_url' (str, optional): Base URL for the OpenRouter API.
+                                                        Defaults to "https://openrouter.ai/api/v1".
+                      - 'default_system_prompt' (str, optional): Default system prompt.
+                      - 'generation_params' (dict, optional): Default generation parameters.
+                      - 'request_timeout' (int, optional): Timeout for HTTP requests. Defaults to 60.
+                      - 'http_referer' (str, optional): HTTP Referer header. Defaults to "http://localhost:3000".
         """
-        super().__init__(config)
+        effective_model_name = model_name or kwargs.get("model_name") or self.DEFAULT_MODEL_NAME
+        super().__init__(model_name=effective_model_name, **kwargs)
 
-        api_key_env_var = config.get("api_key_env_var", "OPENROUTER_API_KEY")
+        api_key_env_var = self._config.get("api_key_env_var", "OPENROUTER_API_KEY")
         self.api_key = os.environ.get(api_key_env_var)
         if not self.api_key:
-            raise ValueError(f"API key not found. Set the {api_key_env_var} environment variable.")
+            raise OpenRouterApiError(f"API key not found. Set the {api_key_env_var} environment variable.")
 
-        self.api_base_url = config.get("api_base_url", self.DEFAULT_API_BASE_URL)
+        self.api_base_url = self._config.get("api_base_url", self.DEFAULT_API_BASE_URL)
         if self.api_base_url.endswith('/'):
             self.api_base_url = self.api_base_url[:-1]
 
-        self.model_name = config.get("model_name", self.DEFAULT_MODEL_NAME)
-        self.default_system_prompt = config.get("default_system_prompt")
-        self.generation_params = config.get("generation_params", {})
-        self.http_referer = config.get("http_referer", "http://localhost:3000") # Example referer
-        request_timeout = config.get("request_timeout", 60) # OpenRouter can sometimes be slow
+        self.default_system_prompt = self._config.get("default_system_prompt")
+        self.generation_params = self._config.get("generation_params", {})
+        self.http_referer = self._config.get("http_referer", "http://localhost:3000") # Example referer
+        request_timeout = self._config.get("request_timeout", 60) # OpenRouter can sometimes be slow
 
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -71,25 +74,33 @@ class OpenRouterConnector(BaseLLMConnector):
             f"base_url: {self.api_base_url}, timeout: {request_timeout}"
         )
         if self.default_system_prompt:
-            logger.info(f"Default system prompt: {self.default_system_prompt[:100]}...")
+            logger.info(f"Default system prompt: {(self.default_system_prompt or '')[:100]}...")
         if self.generation_params:
             logger.info(f"Default generation parameters: {self.generation_params}")
 
 import json # For potential JSON parsing errors
 
-    async def _make_chat_completion_request(self, messages: list, generation_params_override: dict = None) -> str:
+    async def _make_chat_completion_request(self, messages: List[Dict[str, str]], generation_params_override: Optional[Dict[str, Any]] = None) -> str:
         """
         Helper method to make a request to the /chat/completions endpoint.
         """
         payload = {
-            "model": self.model_name,
+            "model": self.model_name, # self.model_name is from BaseLLMConnector
             "messages": messages,
         }
 
         # Merge default generation_params with overrides, then with payload
-        current_generation_params = {**self.generation_params, **(generation_params_override or {})}
-        payload.update(current_generation_params)
+        current_generation_params = self.generation_params.copy()
+        if generation_params_override:
+            current_generation_params.update(generation_params_override)
 
+        # Only add parameters to payload if they have values, to avoid sending e.g. "temperature": null
+        for key, value in current_generation_params.items():
+            if value is not None:
+                payload[key] = value
+        # payload.update(current_generation_params) # Old way, could send None values
+
+        logger.debug(f"OpenRouter request payload: {json.dumps(payload, indent=2)}")
         try:
             response = await self.client.post("/chat/completions", json=payload)
             response.raise_for_status()  # Raises HTTPStatusError for 4xx/5xx responses
@@ -99,136 +110,161 @@ import json # For potential JSON parsing errors
             if not response_data.get("choices") or not response_data["choices"][0].get("message") \
                or "content" not in response_data["choices"][0]["message"]:
                 logger.error(f"Invalid response structure from OpenRouter: {response_data}")
-                raise OpenRouterApiError("Invalid response structure from OpenRouter.", status_code=response.status_code)
+                raise OpenRouterApiError("Invalid response structure from OpenRouter.", status_code=response.status_code, underlying_exception=ValueError(str(response_data)))
 
             content = response_data["choices"][0]["message"]["content"]
-            logger.info(f"Successfully received response from OpenRouter. Choice 0 content length: {len(content)}")
-            return content.strip()
+            logger.info(f"Successfully received response from OpenRouter. Choice 0 content length: {len(content or '')}")
+            return (content or "").strip() # Ensure content is not None before strip
 
         except httpx.RequestError as e:
             logger.error(f"Error connecting to OpenRouter API: {e}")
-            raise OpenRouterApiError(f"Connection to OpenRouter failed: {e}") from e
+            raise OpenRouterApiError(f"Connection to OpenRouter failed: {e}", underlying_exception=e) from e
         except httpx.HTTPStatusError as e:
             logger.error(f"OpenRouter API request failed: {e.response.status_code} - {e.response.text[:200]}")
-            # Attempt to parse error details from OpenRouter response if available
             error_detail = e.response.text
             try:
                 error_json = e.response.json()
-                if error_json and "error" in error_json:
+                if error_json and "error" in error_json: # OpenAI compatible error
                     error_detail = error_json["error"].get("message", error_detail)
+                elif error_json and "detail" in error_json: # Some other proxy errors
+                    error_detail = error_json["detail"]
             except json.JSONDecodeError:
-                pass # Use text if JSON parsing fails
-            raise OpenRouterApiError(f"OpenRouter API error: {e.response.status_code} - {error_detail}", status_code=e.response.status_code) from e
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON response from OpenRouter: {e}")
-            raise OpenRouterApiError(f"Invalid JSON response from OpenRouter: {e}") from e
-        except Exception as e:
+                pass
+            raise OpenRouterApiError(f"OpenRouter API error: {e.response.status_code} - {error_detail}", status_code=e.response.status_code, underlying_exception=e) from e
+        except json.JSONDecodeError as e: # Should be rare if HTTPStatusError parsing works
+            logger.error(f"Failed to parse JSON response from OpenRouter: {e}. Response text: {response.text[:200] if 'response' in locals() else 'N/A'}")
+            raise OpenRouterApiError(f"Invalid JSON response from OpenRouter: {e}", underlying_exception=e) from e
+        except Exception as e: # Catch-all for unexpected errors
             logger.error(f"An unexpected error occurred during OpenRouter request: {e}")
-            raise OpenRouterApiError(f"An unexpected error occurred: {e}") from e
+            raise OpenRouterApiError(f"An unexpected error occurred: {e}", underlying_exception=e) from e
 
 
     async def check_availability(self) -> bool:
         """
-        Checks if the OpenRouter API is available by trying to fetch the list of models.
+        Checks if the OpenRouter API is available by trying to make a cheap request.
         This also implicitly checks if the API key is valid.
         """
-        logger.info(f"Checking OpenRouter API availability and API key validity at {self.api_base_url}...")
+        logger.info(f"Checking OpenRouter API availability and API key validity at {self.api_base_url} using model {self.model_name}...")
         try:
-            # OpenRouter's /models endpoint is suitable for checking key validity and reachability.
-            # It doesn't list all models for all users but confirms the API is responsive.
-            # Alternatively, a very cheap model could be queried with a max_tokens: 1 prompt.
-            response = await self.client.get("/models") # This endpoint might be restricted for some keys
-                                                     # A more universal check might be a simple, cheap chat completion.
-                                                     # For now, we'll assume /models gives some indication or use a test call.
+            test_messages = [{"role": "user", "content": "test"}]
+            # Use minimal generation params for this test call to make it cheap and fast
+            test_gen_params = {"max_tokens": 1, "temperature": 0.0}
 
-            # If /models is restricted, let's try a more direct check using a very simple chat completion.
-            if response.status_code == 401 or response.status_code == 403: # Unauthorized or Forbidden
-                 logger.warning(f"/models endpoint check returned {response.status_code}. Attempting fallback check with test chat completion.")
-                 # Fallback: try a very cheap request to a known free model
-                 test_payload = {
-                     "model": self.model_name or self.DEFAULT_MODEL_NAME, # Use configured or default
-                     "messages": [{"role": "user", "content": "test"}],
-                     "max_tokens": 1
-                 }
-                 response = await self.client.post("/chat/completions", json=test_payload)
-
-            response.raise_for_status() # Check for 4xx/5xx after potential fallback
-
-            # Check if response is as expected (e.g., contains 'data' for /models or 'choices' for chat)
-            response_data = response.json()
-            if "data" in response_data or "choices" in response_data :
-                logger.info("OpenRouter API is available and API key appears valid.")
-                return True
+            await self._make_chat_completion_request(messages=test_messages, generation_params_override=test_gen_params)
+            logger.info("OpenRouter API is available and API key appears valid.")
+            return True
+        except OpenRouterApiError as e: # Catch our specific error from _make_chat_completion_request
+            if e.status_code == 401:
+                logger.error(f"OpenRouter API key is invalid or not authorized. Status: {e.status_code}. Message: {e}")
             else:
-                logger.warning(f"OpenRouter API availability check returned unexpected data structure: {response_data}")
-                return False # Or True, depending on how strict we want to be with /models response
-
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                logger.error(f"OpenRouter API key is invalid or not authorized. Status: {e.response.status_code}")
-            else:
-                logger.error(f"OpenRouter API availability check failed with status {e.response.status_code}: {e.response.text[:200]}")
+                logger.error(f"OpenRouter API availability check failed. Status: {e.status_code}. Message: {e}")
             return False
-        except httpx.RequestError as e:
-            logger.error(f"Error connecting to OpenRouter for availability check: {e}")
-            return False
-        except Exception as e:
+        except Exception as e: # Catch any other unexpected errors
             logger.error(f"An unexpected error occurred during OpenRouter availability check: {e}")
             return False
 
-    async def generate_code(self, user_prompt: str, system_instruction: str = None, context: str = "") -> str:
+    def _prepare_messages(self, user_prompt: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None) -> List[Dict[str, str]]:
         """
-        Generates code based on the given prompt and context using OpenRouter.
+        Prepares the list of messages for the API request, incorporating history and system instructions.
+        History format: [{"role": "user", "text": "..."}, {"role": "assistant", "text": "..."}]
+        OpenAI/OpenRouter format: [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]
         """
+        messages: List[Dict[str, str]] = []
+
+        # 1. Add system instruction if provided
+        active_system_instruction = system_instruction if system_instruction is not None else self.default_system_prompt
+        if active_system_instruction: # Ensure it's not None or empty string
+            messages.append({"role": "system", "content": active_system_instruction})
+
+        # 2. Add history
+        if history:
+            for item in history:
+                # Transform role and content key
+                role = item.get("role")
+                # Prioritize "text", then "content". Could be made more robust.
+                content = item.get("text") or item.get("content")
+
+                if role and content:
+                    # Ensure role is one of "user", "assistant", "system" (though system usually first)
+                    # OpenAI/OpenRouter typically expect "user" or "assistant" for history turns.
+                    # If a "system" role is in history, it might be from a previous turn's system_instruction.
+                    # For simplicity, we'll pass it as is, but it's usually best for "system" to be at the start.
+                    valid_roles = ["user", "assistant", "system"]
+                    if role not in valid_roles:
+                        logger.warning(f"History item has invalid role '{role}'. Skipping.")
+                        continue
+                    messages.append({"role": role, "content": content})
+                else:
+                    logger.warning(f"History item missing role or content: {item}. Skipping.")
+
+        # 3. Add current user prompt
+        if user_prompt: # Ensure user_prompt is not empty
+             messages.append({"role": "user", "content": user_prompt})
+        else:
+            # This case should ideally be prevented by callers or raise an error.
+            # If the last message is not from 'user', many models will error.
+            # If messages is empty and no user_prompt, _make_chat_completion_request will likely fail.
+            logger.warning("User prompt is empty. The API call might fail if messages list is empty or ends with non-user role.")
+            if not messages or messages[-1]["role"] != "user":
+                 # Add a minimal user message if list is empty or last message is not user to prevent errors
+                 # This is a fallback, ideally user_prompt should always be present.
+                 # messages.append({"role": "user", "content": "..."}) # Or raise error
+                 pass # Let it proceed, _make_chat_completion_request might handle empty messages scenario if needed (e.g. raise error)
+
+
+        return messages
+
+    async def generate_code(self, user_prompt: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
         logger.info(f"generate_code called with user_prompt: {user_prompt[:50]}...")
+        # The 'context' parameter from the old signature is not used here.
+        # If context is needed, it should be part of the user_prompt or history.
 
-        messages = []
-        current_system_prompt = system_instruction if system_instruction is not None else self.default_system_prompt
-        if current_system_prompt:
-            messages.append({"role": "system", "content": current_system_prompt})
+        messages = self._prepare_messages(user_prompt, system_instruction, history)
+        if not messages: # Should not happen if user_prompt is guaranteed
+            raise OpenRouterApiError("Cannot generate code with an empty message list (no user_prompt and no history).")
 
-        full_user_prompt = f"{context}\n\n{user_prompt}" if context else user_prompt
-        messages.append({"role": "user", "content": full_user_prompt})
+        # Allow overriding generation_params via kwargs if needed, e.g., kwargs.get("generation_params_override")
+        generation_params_override = kwargs.get("generation_params")
+        return await self._make_chat_completion_request(messages, generation_params_override=generation_params_override)
 
-        return await self._make_chat_completion_request(messages)
-
-    async def explain_code(self, code_snippet: str, system_instruction: str = None, context: str = "") -> str:
-        """
-        Explains the given code snippet using OpenRouter.
-        """
+    async def explain_code(self, code_snippet: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
         logger.info(f"explain_code called for code snippet: {code_snippet[:50]}...")
 
-        messages = []
-        current_system_prompt = system_instruction
-        if current_system_prompt is None:
-            current_system_prompt = self.default_system_prompt if self.default_system_prompt \
-                                 else "You are an expert code explainer. Provide clear and concise explanations for the given code."
-        messages.append({"role": "system", "content": current_system_prompt})
+        user_content = f"Please explain the following code snippet:\n```\n{code_snippet}\n```"
 
-        user_content = f"{context}\n\nPlease explain the following code snippet:\n```\n{code_snippet}\n```" if context \
-                       else f"Please explain the following code snippet:\n```\n{code_snippet}\n```"
-        messages.append({"role": "user", "content": user_content})
+        # Use a default system prompt if none provided and default_system_prompt is not set
+        effective_system_instruction = system_instruction
+        if effective_system_instruction is None and self.default_system_prompt is None:
+            effective_system_instruction = "You are an expert code explainer. Provide clear and concise explanations for the given code."
+        # If system_instruction is provided, it's used. If None, self.default_system_prompt is used by _prepare_messages.
+        # The above line sets a specific default only if no other system prompt would be chosen.
 
-        return await self._make_chat_completion_request(messages)
+        messages = self._prepare_messages(user_content, effective_system_instruction, history)
+        if not messages:
+            raise OpenRouterApiError("Cannot explain code with an empty message list.")
 
-    async def suggest_code_modification(self, code_snippet: str, instruction: str, system_instruction: str = None, context: str = "") -> str:
-        """
-        Suggests modifications to the code snippet based on the instruction using OpenRouter.
-        """
-        logger.info(f"suggest_code_modification called for code: {code_snippet[:50]} with instruction: {instruction}")
+        generation_params_override = kwargs.get("generation_params")
+        return await self._make_chat_completion_request(messages, generation_params_override=generation_params_override)
 
-        messages = []
-        current_system_prompt = system_instruction
-        if current_system_prompt is None:
-            current_system_prompt = self.default_system_prompt if self.default_system_prompt \
-                                 else "You are an expert code modification assistant. Given a code snippet and an instruction, provide the modified code or a clear description of changes."
-        messages.append({"role": "system", "content": current_system_prompt})
+    async def suggest_code_modification(self, code_snippet: str, issue_description: str, system_instruction: Optional[str] = None, history: Optional[List[Dict[str, str]]] = None, **kwargs: Any) -> Optional[str]:
+        logger.info(f"suggest_code_modification called for code: {code_snippet[:50]} with issue: {issue_description[:50]}")
 
-        user_content = f"{context}\n\nCode snippet:\n```\n{code_snippet}\n```\n\nInstruction for modification: {instruction}\n\nPlease provide the modified code snippet or explain the necessary changes." if context \
-                       else f"Code snippet:\n```\n{code_snippet}\n```\n\nInstruction for modification: {instruction}\n\nPlease provide the modified code snippet or explain the necessary changes."
-        messages.append({"role": "user", "content": user_content})
+        user_content = (
+            f"Code snippet:\n```\n{code_snippet}\n```\n\n"
+            f"Issue/Request for modification: {issue_description}\n\n"
+            "Please provide the modified code snippet."
+        )
 
-        return await self._make_chat_completion_request(messages)
+        effective_system_instruction = system_instruction
+        if effective_system_instruction is None and self.default_system_prompt is None:
+            effective_system_instruction = "You are an expert code modification assistant. Given a code snippet and an instruction, provide the modified code snippet."
+
+        messages = self._prepare_messages(user_content, effective_system_instruction, history)
+        if not messages:
+            raise OpenRouterApiError("Cannot suggest code modification with an empty message list.")
+
+        generation_params_override = kwargs.get("generation_params")
+        return await self._make_chat_completion_request(messages, generation_params_override=generation_params_override)
 
     async def close(self):
         """

--- a/jarules_agent/electron_bridge/send_prompt_wrapper.py
+++ b/jarules_agent/electron_bridge/send_prompt_wrapper.py
@@ -2,7 +2,9 @@ import json
 import os
 import sys
 import argparse
-import asyncio # Required if using async methods from LLM client
+import asyncio
+from pathlib import Path # Added pathlib
+from typing import List, Dict, Optional # For type hinting
 
 # Adjust path (similar to other wrappers)
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -14,39 +16,111 @@ try:
     from jarules_agent.core.llm_manager import LLMManager, LLMConfigError, LLMManagerError
     from jarules_agent.connectors.base_llm_connector import LLMConnectorError
 except ModuleNotFoundError:
-    # This is a critical error before streaming can even be attempted.
     print(json.dumps({"error": True, "message": "ModuleNotFoundError: Could not import LLMManager or related classes.", "details": "Python environment or script path issue."}))
-    sys.stdout.flush() # Though not strictly streaming, good practice
+    sys.stdout.flush()
     sys.exit(1)
 
-# Import time for simulated streaming delay
 import time
+
+# --- Configuration File Paths ---
+JARULES_DIR = Path.home() / ".jarules"
+CHAT_HISTORY_FILE = JARULES_DIR / "chat_history.json"
+USER_STATE_FILE = JARULES_DIR / "user_state.json"
+DEFAULT_CONTEXT_MESSAGE_COUNT = 10 # Default number of past messages to include if not in user_state.json
+
+def load_chat_history(history_file_path: Path, num_messages: int) -> List[Dict[str, str]]:
+    """
+    Loads and formats the last num_messages from the chat history file.
+    """
+    if not history_file_path.exists():
+        return []
+
+    try:
+        with open(history_file_path, 'r', encoding='utf-8') as f:
+            history_data = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        # Log this error to stderr or a proper logging mechanism if available
+        print(json.dumps({"type": "error", "message": "Error loading chat history", "details": f"Failed to read or parse {history_file_path}: {e}"}), file=sys.stderr)
+        return []
+
+    if not isinstance(history_data, list):
+        print(json.dumps({"type": "error", "message": "Invalid chat history format", "details": f"Expected a list in {history_file_path}, got {type(history_data)}"}), file=sys.stderr)
+        return []
+
+    # Get the last num_messages
+    relevant_messages_raw = history_data[-num_messages:]
+
+    formatted_messages: List[Dict[str, str]] = []
+    for msg in relevant_messages_raw:
+        sender = msg.get("sender")
+        text = msg.get("text")
+
+        if not sender or not text:
+            # Log malformed message
+            print(json.dumps({"type": "warning", "message": "Skipping malformed message in chat history", "details": f"Message missing sender or text: {msg}"}), file=sys.stderr)
+            continue
+
+        role = "user" if sender == "user" else "assistant" # Default unknown senders to assistant or skip
+        if sender not in ["user", "assistant"]: # Be more specific or handle other potential senders
+             # For now, skip if not user or assistant to match expected roles
+            print(json.dumps({"type": "warning", "message": "Skipping message with unknown sender type in chat history", "details": f"Unknown sender: {sender}"}), file=sys.stderr)
+            continue
+
+        formatted_messages.append({"role": role, "text": text})
+
+    return formatted_messages
+
 
 async def send_prompt_to_llm_streaming(prompt: str, provider_id: str):
     """
-    Uses LLMManager to get a client and sends the prompt.
-    If provider_id is 'ollama_default_local' (or similar, for testing), it simulates streaming.
-    Otherwise, it sends a single response (compatibility mode or for non-streaming providers).
-    Outputs multiple JSON strings, each on a new line, for streaming.
+    Uses LLMManager to get a client, loads chat history, and sends the prompt.
+    Simulates streaming for 'ollama_default_local', actual calls for others.
+    Outputs multiple JSON strings for streaming.
     """
     config_path = os.path.join(project_root, 'config', 'llm_config.yaml')
+    loaded_history: List[Dict[str, str]] = []
+
+    # Determine context_message_count
+    context_message_count = DEFAULT_CONTEXT_MESSAGE_COUNT
+    if USER_STATE_FILE.exists():
+        try:
+            with open(USER_STATE_FILE, 'r', encoding='utf-8') as f:
+                user_state_data = json.load(f)
+            if isinstance(user_state_data, dict):
+                config_count = user_state_data.get("context_message_count")
+                if isinstance(config_count, int) and config_count > 0:
+                    context_message_count = config_count
+                elif config_count is not None: # Exists but invalid
+                    print(json.dumps({"type": "warning", "message": "Invalid context_message_count in user_state.json", "details": f"Expected positive integer, got {config_count}. Using default {DEFAULT_CONTEXT_MESSAGE_COUNT}."}), file=sys.stderr)
+            else:
+                print(json.dumps({"type": "warning", "message": "Invalid user_state.json format", "details": f"Expected a JSON object, got {type(user_state_data)}. Using default {DEFAULT_CONTEXT_MESSAGE_COUNT}."}), file=sys.stderr)
+        except (IOError, json.JSONDecodeError) as e:
+            print(json.dumps({"type": "warning", "message": "Error reading user_state.json", "details": str(e) + f". Using default {DEFAULT_CONTEXT_MESSAGE_COUNT}."}), file=sys.stderr)
+
+    # print(json.dumps({"type": "debug", "message": f"Using context_message_count: {context_message_count}"}), file=sys.stderr) # Optional debug line
 
     try:
+        # Ensure .jarules directory exists (for both history and state file)
+        JARULES_DIR.mkdir(parents=True, exist_ok=True)
+
+        loaded_history = load_chat_history(CHAT_HISTORY_FILE, context_message_count) # Use determined count
+
+
         manager = LLMManager(config_path=config_path)
         if not provider_id or provider_id.lower() == "null" or provider_id.lower() == "undefined":
             print(json.dumps({"type": "error", "message": "No active model ID provided to the script.", "details": "Provider ID was null or undefined."}))
             sys.stdout.flush()
             return
 
-        # Start of stream signal
         print(json.dumps({"type": "stream_start"}))
         sys.stdout.flush()
 
-        # Simulate streaming for 'ollama_default_local'
         if provider_id == "ollama_default_local":
-            time.sleep(0.1) # Simulate initial delay
-            simulated_text = f"Simulated streaming response for '{prompt}' from {provider_id}: "
-            words = ["This", "is", "a", "streamed", "response", ".", "One", "token", "at", "a", "time", "!"]
+            time.sleep(0.1)
+            # Simulate history usage in log or output
+            history_notice = f"(Simulating with history of {len(loaded_history)} messages) " if loaded_history else ""
+            simulated_text = f"Simulated streaming for '{prompt}' from {provider_id} {history_notice}: "
+            words = ["This", "is", "a", "streamed", "response", "reflecting", "potential", "history", "use."]
             full_response_text = ""
             for word in words:
                 chunk_text = f"{word} "
@@ -57,17 +131,25 @@ async def send_prompt_to_llm_streaming(prompt: str, provider_id: str):
             print(json.dumps({"type": "done", "full_response": full_response_text.strip()}))
             sys.stdout.flush()
         else:
-            # Non-streaming behavior for other providers (actual call)
             llm_client = manager.get_llm_client(provider_id=provider_id)
-            response_text = await llm_client.generate_code(prompt)
+            # Pass the loaded_history to generate_code
+            response_text = await llm_client.generate_code(prompt, history=loaded_history)
 
-            print(json.dumps({"type": "chunk", "token": response_text}))
+            if response_text is None: # Handle cases where connector might return None (e.g. safety block)
+                print(json.dumps({"type": "error", "message": "LLM did not return a response.", "details": "The response from the LLM client was None."}))
+                sys.stdout.flush()
+                # Ensure "done" is still sent to terminate stream on client side
+                print(json.dumps({"type": "done", "full_response": None}))
+                sys.stdout.flush()
+                return
+
+            print(json.dumps({"type": "chunk", "token": response_text})) # Send as one chunk for non-streaming actual call
             sys.stdout.flush()
             print(json.dumps({"type": "done", "full_response": response_text}))
             sys.stdout.flush()
 
     except LLMManagerError as e:
-        print(json.dumps({"type": "error", "message": f"LLMManager Error", "details": str(e)}))
+        print(json.dumps({"type": "error", "message": "LLMManager Error", "details": str(e)}))
         sys.stdout.flush()
     except LLMConnectorError as e:
         print(json.dumps({"type": "error", "message": f"LLMConnector Error ({provider_id})", "details": str(e)}))


### PR DESCRIPTION
This commit introduces a basic context management system for the Electron UI interactions with the LLM.

Key changes:
- LLM connectors (`GeminiClient`, `OllamaConnector`, `OpenRouterConnector`, `ClaudeConnector`) have been updated to accept an optional `history` parameter. They will prepend this history to your prompt when interacting with the LLM.
- `send_prompt_wrapper.py` now loads recent messages from `~/.jarules/chat_history.json` to provide context to the LLM.
- The number of messages included in the context can be configured by setting the `context_message_count` key in `~/.jarules/user_state.json`. If not set, a default of 10 messages is used.
- The existing "Clear Chat History" functionality in the Electron UI also serves to clear/reset the context, as it deletes the chat history file that the backend reads from.

Manual testing steps have been outlined to verify this functionality, including checking context inclusion, the effect of the `context_message_count` setting, and the context clearing mechanism.