### PR TITLE
feat: Implement read-only in-app configuration UI

### DIFF
--- a/jarules_electron_vue_ui/main.js
+++ b/jarules_electron_vue_ui/main.js
@@ -1,5 +1,6 @@
 const { app, BrowserWindow, ipcMain } = require('electron'); // Ensure ipcMain is imported here
 const path = require('path');
+const fs = require('fs/promises');
 const { PythonShell } = require('python-shell');
 
 // Determine if running in development or production
@@ -211,6 +212,22 @@ app.whenReady().then(async () => {
         console.log('[IPC Main] PythonShell execution finished successfully (code, signal):', code, signal);
       }
     });
+  });
+
+  // --- LLM Configuration IPC Handler ---
+  ipcMain.handle('get-llm-config', async () => {
+    try {
+      // __dirname is jarules_electron_vue_ui/
+      // config/ is at the project root, so one level up from __dirname
+      const configPath = path.join(__dirname, '../config/llm_config.yaml');
+      const data = await fs.readFile(configPath, 'utf8');
+      return data;
+    } catch (error) {
+      console.error('Failed to read llm_config.yaml:', error);
+      // Return null or an error object, depending on how the renderer should handle it
+      // For consistency with other handlers that might return data or error states:
+      return { error: true, message: 'Failed to read LLM configuration.', details: error.message };
+    }
   });
 
   // --- Chat History IPC Handlers ---

--- a/jarules_electron_vue_ui/package-lock.json
+++ b/jarules_electron_vue_ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "js-yaml": "^4.1.0",
         "python-shell": "^5.0.0",
         "vue": "^3.5.16"
       },
@@ -960,6 +961,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -1584,6 +1590,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/json-buffer": {

--- a/jarules_electron_vue_ui/package.json
+++ b/jarules_electron_vue_ui/package.json
@@ -46,6 +46,7 @@
     "vite": "^6.3.5"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "python-shell": "^5.0.0",
     "vue": "^3.5.16"
   }

--- a/jarules_electron_vue_ui/preload.js
+++ b/jarules_electron_vue_ui/preload.js
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld('api', {
   listAvailableModels: () => ipcRenderer.invoke('listAvailableModels'),
   getActiveModel: () => ipcRenderer.invoke('getActiveModel'),
   setActiveModel: (modelId) => ipcRenderer.invoke('setActiveModel', modelId),
+  getConfig: () => ipcRenderer.invoke('get-llm-config'), // Added for LLM config
   // sendPrompt: (prompt) => ipcRenderer.invoke('sendPrompt', prompt), // OLD request-response
 
   // NEW for streaming:

--- a/jarules_electron_vue_ui/src/App.vue
+++ b/jarules_electron_vue_ui/src/App.vue
@@ -64,6 +64,11 @@
 
     <!-- Prompt Input Area -->
     <ChatInput @send-prompt="handleSendPrompt" :is-streaming="isStreaming" />
+
+    <!-- Configuration Display Area -->
+    <div class="config-area">
+      <ConfigurationDisplay />
+    </div>
   </div>
 </template>
 
@@ -71,6 +76,7 @@
 import { ref, onMounted, onBeforeUnmount, computed, nextTick } from 'vue';
 import MessageDisplay from './components/MessageDisplay.vue';
 import ChatInput from './components/ChatInput.vue';
+import ConfigurationDisplay from './components/ConfigurationDisplay.vue'; // Added import
 
 const message = ref('Hello from JaRules (Electron + Vue.js + Vite!)');
 const versions = ref({ electron: '', node: '', chrome: '' });
@@ -522,7 +528,7 @@ p.feedback-message {
 
 
 /* Chat messages display area */
-.chat-display-area {
+.chat-display-area { /* This class is not used on MessageDisplay directly, but similar styling is in MessageDisplay.vue */
   flex-grow: 1;
   overflow-y: auto;
   padding: 10px;
@@ -531,38 +537,10 @@ p.feedback-message {
   border-radius: 4px;
   margin-bottom: 10px;
 }
-.message {
-  margin-bottom: 10px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  word-wrap: break-word;
-  white-space: pre-wrap;
-  max-width: 90%;
-}
-.message.user {
-  background-color: #007bff;
-  color: white;
-  margin-left: auto;
-  border-bottom-right-radius: 0;
-}
-.message.assistant {
-  background-color: #e9ecef;
-  color: #343a40;
-  margin-right: auto;
-  border-bottom-left-radius: 0;
-}
-.message.error {
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
-}
-.streaming-indicator {
-  font-style: italic;
-  color: #6c757d;
-}
+/* MessageDisplay.vue has its own styles for .message, .user, .assistant etc. */
 
 
-.prompt-test {
+.prompt-test { /* This class is from an old version or example, ChatInput.vue has its own styling */
   display: flex;
   padding: 10px;
   border: 1px solid #ced4da;
@@ -607,8 +585,6 @@ p.feedback-message {
   justify-content: space-between;
   align-items: center;
   box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-  /* position: sticky; Removed sticky as it complicates padding on #app-container */
-  /* top: 0; */
   z-index: 1000;
   flex-shrink: 0; /* Prevent banner from shrinking */
 }
@@ -666,5 +642,14 @@ p.feedback-message {
   padding: 15px;
   font-style: italic;
   color: #6c757d;
+}
+
+.config-area { /* Added style */
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #dee2e6; /* A subtle separator */
+  flex-shrink: 0; /* Prevent it from shrinking if content above grows */
+  max-height: 300px; /* Example max height, adjust as needed */
+  overflow-y: auto; /* Allow scrolling if content is taller than max-height */
 }
 </style>

--- a/jarules_electron_vue_ui/src/components/ConfigurationDisplay.vue
+++ b/jarules_electron_vue_ui/src/components/ConfigurationDisplay.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="configuration-display">
+    <h2>LLM Configuration</h2>
+    <div v-if="error" class="error-message">
+      <p>Error loading configuration:</p>
+      <pre>{{ error }}</pre>
+    </div>
+    <div v-else-if="typeof configurationContent === 'object'">
+      <pre>{{ JSON.stringify(configurationContent, null, 2) }}</pre>
+    </div>
+    <div v-else>
+      <pre>{{ configurationContent }}</pre>
+    </div>
+  </div>
+</template>
+
+<script>
+import jsyaml from 'js-yaml';
+
+export default {
+  name: 'ConfigurationDisplay',
+  data() {
+    return {
+      configurationContent: 'Loading configuration...', // Will hold the parsed object or error string
+      error: null,
+    };
+  },
+  async mounted() {
+    await this.fetchConfiguration();
+  },
+  methods: {
+    async fetchConfiguration() {
+      try {
+        this.error = null;
+        // In Electron, the getConfig function might return the raw data or an object with an error property
+        const result = await window.api.getConfig();
+
+        // Check if the main process returned an error object
+        if (result && result.error) {
+          console.error('Error from main process getConfig:', result.message, result.details);
+          this.configurationContent = `Error loading configuration: ${result.message}`;
+          this.error = `Error loading configuration: ${result.message}${result.details ? ' - ' + result.details : ''}`;
+          return;
+        }
+
+        const yamlString = result; // Assuming result is the yaml string if not an error object
+
+        if (yamlString && typeof yamlString === 'string') {
+          this.configurationContent = jsyaml.load(yamlString);
+        } else if (yamlString) { // It's not a string, but not an error object from main, could be already parsed? Or unexpected.
+          // This case handles if getConfig for some reason returns already parsed JSON or non-string data.
+          // For now, we assume it's an unexpected format if not a string.
+          console.warn('Received non-string data from getConfig, attempting to display as is or use directly if object:', yamlString);
+          if (typeof yamlString === 'object') {
+            this.configurationContent = yamlString; // If it's an object, use it directly
+          } else {
+            this.configurationContent = 'Failed to load configuration: Invalid format received.';
+            this.error = 'Failed to load configuration: Invalid format received.';
+          }
+        } else { // Null or undefined yamlString
+          this.configurationContent = 'Failed to load configuration: No content received.';
+          this.error = 'Failed to load configuration: No content received.';
+        }
+      } catch (err) { // Catches errors from jsyaml.load or other unexpected issues
+        console.error('Error fetching or parsing configuration:', err);
+        this.configurationContent = `Error loading configuration: ${err.message}`;
+        this.error = `Error loading configuration: ${err.message}`;
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.configuration-display {
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin: 1rem;
+}
+pre {
+  background-color: #f5f5f5;
+  padding: 0.5rem;
+  border-radius: 4px;
+  white-space: pre-wrap; /* Allow text wrapping */
+  word-break: break-all; /* Break long words */
+}
+.error-message {
+  color: red;
+  border: 1px solid red;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+.error-message pre {
+  color: red;
+  background-color: #ffe0e0;
+}
+</style>

--- a/jarules_electron_vue_ui/src/components/__tests__/ConfigurationDisplay.spec.js
+++ b/jarules_electron_vue_ui/src/components/__tests__/ConfigurationDisplay.spec.js
@@ -1,0 +1,97 @@
+// jarules_electron_vue_ui/src/components/__tests__/ConfigurationDisplay.spec.js
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest'; // Or Jest equivalents
+import ConfigurationDisplay from '../ConfigurationDisplay.vue';
+import jsyaml from 'js-yaml';
+
+// Mock the global window.api.getConfig
+// Ensure this setup is compatible with the test environment (e.g., JSDOM for Vitest/Jest)
+if (typeof global.window === 'undefined') {
+  global.window = {};
+}
+global.window.api = {
+  getConfig: vi.fn(),
+  ...(global.window.api || {}) // Preserve other api functions if any
+};
+
+
+describe('ConfigurationDisplay.vue', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    window.api.getConfig.mockReset();
+  });
+
+  it('renders loading state initially', () => {
+    window.api.getConfig.mockReturnValueOnce(new Promise(() => {})); // Keep it pending, effectively a never-resolving promise
+    const wrapper = mount(ConfigurationDisplay);
+    expect(wrapper.text()).toContain('Loading configuration...');
+  });
+
+  it('fetches and displays configuration on mount', async () => {
+    const mockConfig = { gemini: { api_key: 'GEMINI_API_KEY' }, default_provider: 'gemini' };
+    const yamlString = jsyaml.dump(mockConfig);
+    window.api.getConfig.mockResolvedValueOnce(yamlString);
+
+    const wrapper = mount(ConfigurationDisplay);
+    // Wait for promises to resolve and component to update
+    await new Promise(resolve => setTimeout(resolve, 0)); // Allow mounted and fetchConfiguration to run
+    await wrapper.vm.$nextTick(); // Allow Vue to re-render
+
+    // Check if JSON stringified output is present
+    expect(wrapper.text()).toContain('"gemini":');
+    expect(wrapper.text()).toContain('"api_key": "GEMINI_API_KEY"');
+    expect(wrapper.text()).toContain('"default_provider": "gemini"');
+    expect(wrapper.find('.error-message').exists()).toBe(false);
+  });
+
+  it('displays error message if config loading via IPC fails (rejected promise)', async () => {
+    window.api.getConfig.mockRejectedValueOnce(new Error('IPC Failed to load'));
+    const wrapper = mount(ConfigurationDisplay);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.error-message').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Error loading configuration: IPC Failed to load');
+  });
+
+  it('displays error message if getConfig returns an error object', async () => {
+    const errorResponse = { error: true, message: "File not found", details: "config/llm_config.yaml could not be read." };
+    window.api.getConfig.mockResolvedValueOnce(errorResponse);
+
+    const wrapper = mount(ConfigurationDisplay);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.error-message').exists()).toBe(true);
+    expect(wrapper.text()).toContain(`Error loading configuration: ${errorResponse.message}`);
+    expect(wrapper.text()).toContain(errorResponse.details);
+  });
+
+
+  it('displays error message if config content is null', async () => {
+    window.api.getConfig.mockResolvedValueOnce(null);
+    const wrapper = mount(ConfigurationDisplay);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.error-message').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Failed to load configuration: No content received.');
+  });
+
+  it('displays error message if YAML parsing fails', async () => {
+    const invalidYamlString = "gemini: api_key: 'GEMINI_API_KEY"; // Missing quote
+    window.api.getConfig.mockResolvedValueOnce(invalidYamlString);
+
+    const wrapper = mount(ConfigurationDisplay);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.error-message').exists()).toBe(true);
+    // The exact error message from js-yaml can be brittle to test, so check for a part of it.
+    // Example: "YAMLException: unexpected end of the stream within a single quoted scalar at line 1, column 20:"
+    // Or "StringParseException: unexpected end of the stream within a single quoted scalar" for older js-yaml
+    expect(wrapper.text()).toContain('Error loading configuration:');
+    // More robustly, check that it's not trying to display the invalid YAML as an object
+    expect(wrapper.text()).not.toContain('"gemini":');
+  });
+});


### PR DESCRIPTION
This commit introduces a new section in the Electron UI to display the contents of `llm_config.yaml` in a user-friendly, read-only format.

Key changes:
- Added `ConfigurationDisplay.vue`: A new Vue component to fetch, parse (using js-yaml), and display the LLM configuration.
- Implemented IPC communication:
    - Main process (`main.js`): Added `get-llm-config` handler to read `llm_config.yaml`.
    - Preload script (`preload.js`): Exposed `window.api.getConfig` to the renderer process.
- Integrated into App: `ConfigurationDisplay.vue` is now part of `App.vue`, appearing below the chat interface.
- Added Unit Tests: Included tests for `ConfigurationDisplay.vue` covering loading, successful display, and various error handling scenarios (IPC failures, YAML parsing errors).
- Installed `js-yaml` dependency for YAML parsing in the UI.

This feature allows you to easily view the current LLM configurations without needing to manually open the YAML file, fulfilling the "In-App Configuration UI (Read-Only First)" part of the Electron UI Phase 2 plan.