### PR TITLE
feat: Implement Stop Generation functionality

### DIFF
--- a/jarules_agent/electron_bridge/send_prompt_wrapper.py
+++ b/jarules_agent/electron_bridge/send_prompt_wrapper.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import signal # Added signal
 import argparse
 import asyncio
 from pathlib import Path # Added pathlib
@@ -11,6 +12,21 @@ script_dir = os.path.dirname(os.path.abspath(__file__))
 project_root = os.path.abspath(os.path.join(script_dir, '..', '..'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
+
+# --- Stop Generation Signal Handling ---
+STOP_GENERATION_FLAG = False
+
+def handle_stop_signal(signum, frame):
+    """Sets the stop generation flag when SIGUSR1 is received."""
+    global STOP_GENERATION_FLAG
+    STOP_GENERATION_FLAG = True
+    # Optional: print a debug message to stderr to confirm signal reception
+    print(json.dumps({"type": "debug", "message": "Stop signal received, attempting to halt generation."}), file=sys.stderr)
+    sys.stderr.flush()
+
+# Register the signal handler for SIGUSR1
+signal.signal(signal.SIGUSR1, handle_stop_signal)
+# --- End Stop Generation Signal Handling ---
 
 try:
     from jarules_agent.core.llm_manager import LLMManager, LLMConfigError, LLMManagerError
@@ -123,17 +139,37 @@ async def send_prompt_to_llm_streaming(prompt: str, provider_id: str):
             words = ["This", "is", "a", "streamed", "response", "reflecting", "potential", "history", "use."]
             full_response_text = ""
             for word in words:
+                if STOP_GENERATION_FLAG:
+                    break
                 chunk_text = f"{word} "
                 full_response_text += chunk_text
                 print(json.dumps({"type": "chunk", "token": chunk_text}))
                 sys.stdout.flush()
                 time.sleep(0.05)
-            print(json.dumps({"type": "done", "full_response": full_response_text.strip()}))
-            sys.stdout.flush()
+
+            if STOP_GENERATION_FLAG:
+                print(json.dumps({"type": "done", "cancelled": True, "message": "Generation stopped by user"}))
+                sys.stdout.flush()
+                return # Exit after sending cancelled message
+            else:
+                print(json.dumps({"type": "done", "full_response": full_response_text.strip()}))
+                sys.stdout.flush()
         else:
+            # Check before starting generation for other clients
+            if STOP_GENERATION_FLAG:
+                print(json.dumps({"type": "done", "cancelled": True, "message": "Generation stopped by user before starting"}))
+                sys.stdout.flush()
+                return
+
             llm_client = manager.get_llm_client(provider_id=provider_id)
             # Pass the loaded_history to generate_code
             response_text = await llm_client.generate_code(prompt, history=loaded_history)
+
+            # Check if stop was signalled during llm_client.generate_code
+            if STOP_GENERATION_FLAG:
+                print(json.dumps({"type": "done", "cancelled": True, "message": "Generation stopped by user during LLM call"}))
+                sys.stdout.flush()
+                return
 
             if response_text is None: # Handle cases where connector might return None (e.g. safety block)
                 print(json.dumps({"type": "error", "message": "LLM did not return a response.", "details": "The response from the LLM client was None."}))

--- a/jarules_electron_vue_ui/src/App.vue
+++ b/jarules_electron_vue_ui/src/App.vue
@@ -319,6 +319,7 @@ async function handleSendPrompt(promptText) {
     if (assistantMsg) {
       // If message indicates cancellation, make it less like a typical error
       if (errorMsg.cancelled) {
+          assistantMsg.text = assistantMsg.text.replace(" [Generation stopped by user]", ""); // Remove optimistic message
           assistantMsg.text += errorMsg.message ? ` [${errorMsg.message}]` : " [Generation Cancelled by User]";
           assistantMsg.error = false; // Not a typical error state
       } else {
@@ -344,7 +345,8 @@ async function handleSendPrompt(promptText) {
     const assistantMsg = chatMessages.value.find(m => m.id === currentAssistantMessageId.value);
     if (assistantMsg) {
       if (doneMsg.cancelled) { // NEW: Check for a 'cancelled' flag from backend
-        assistantMsg.text += doneMsg.message ? ` [${doneMsg.message}]` : " [Generation Cancelled]";
+        assistantMsg.text = assistantMsg.text.replace(" [Generation stopped by user]", ""); // Remove optimistic message
+        assistantMsg.text += doneMsg.message ? ` [${doneMsg.message}]` : " [Generation Cancelled by User]"; // Harmonized message
         assistantMsg.isStreaming = false;
       } else if (doneMsg.success && doneMsg.full_response) {
         // assistantMsg.text = doneMsg.full_response; // Full response might be too much if appending chunks


### PR DESCRIPTION
This commit introduces the "Stop Generation" feature, allowing you to interrupt and halt actively streaming Large Language Model (LLM) responses.

Key changes:

-   **UI (App.vue)**:
    -   A "Stop Generating" button is now visible when an LLM response is streaming (`isStreaming` is true).
    -   Clicking the button calls `window.api.stopGeneration()`.
    -   Optimistically updates UI by setting `isStreaming` to `false` and appending "[Generation stopped by you]" to the assistant's message.
    -   Refined `onDone` and `onError` callbacks to handle a `cancelled: true` flag from the backend, ensuring the correct final message is displayed and avoiding duplicates.

-   **IPC (main.js, preload.js)**:
    -   Added an IPC handler `stop-llm-generation` in `main.js`.
    -   This handler sends a `SIGUSR1` signal to the Python script responsible for LLM streaming.
    -   Manages the `PythonShell` instance to ensure signals are sent to the correct process.
    -   `preload.js` was verified to already expose `stopGeneration`.

-   **Backend (send_prompt_wrapper.py)**:
    -   Added a signal handler for `SIGUSR1` to set a `STOP_GENERATION_FLAG`.
    -   The streaming function now checks this flag and, if set, ceases sending data chunks.
    -   Sends a `{"type": "done", "cancelled": True, "message": "..."}` JSON message to `main.js` upon successful interruption.

This feature enhances your control by providing a way to stop lengthy or unwanted LLM responses.