### PR TITLE
feat: Implement read-only In-App Configuration UI

### DIFF
--- a/jarules_electron_vue_ui/src/components/ConfigNodeViewer.vue
+++ b/jarules_electron_vue_ui/src/components/ConfigNodeViewer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="config-node-viewer">
-    <strong v-if="nodeTitle" class="node-title">{{ formatKey(nodeTitle) }}:</strong>
+    <strong v-if="nodeTitle" :class="['node-title', getNodeTitleClass(nodeTitle)]">{{ formatKey(nodeTitle) }}:</strong>
     <div v-if="isObject(nodeData)" class="config-object">
       <ul>
         <li v-for="(value, key) in nodeData" :key="key">
@@ -9,14 +9,17 @@
       </ul>
     </div>
     <div v-else-if="isArray(nodeData)" class="config-array">
-      <strong v-if="!nodeTitle && isArray(nodeData)" class="node-title array-title">Array Items:</strong>
+      <strong v-if="nodeTitle && formatKey(nodeTitle).toLowerCase().includes('items')" class="node-title array-title">
+        {{ formatKey(nodeTitle) }}:
+      </strong>
+      <strong v-else-if="!nodeTitle" class="node-title array-title">Array Items:</strong>
       <ul>
         <li v-for="(item, index) in nodeData" :key="index">
           <ConfigNodeViewer :node-data="item" :node-title="String(index)" />
         </li>
       </ul>
     </div>
-    <div v-else class="config-value">
+    <div v-else :class="['config-value', getValueClass(nodeData)]">
       {{ displayValue(nodeData) }}
     </div>
   </div>
@@ -56,18 +59,37 @@ export default {
       if (typeof value === 'boolean') return value ? 'Enabled' : 'Disabled';
 
       // Special handling for API keys for security
-      if (this.nodeTitle) {
-        const titleLower = this.nodeTitle.toLowerCase();
-        if ((titleLower.includes('api') && titleLower.includes('key')) || titleLower.includes('token') || titleLower.includes('secret')) {
-            if (typeof value === 'string' && value.length > 4) {
+      // Use the formatted key for checking, not the raw nodeTitle prop directly
+      const currentFormattedKey = this.nodeTitle ? this.formatKey(this.nodeTitle).toLowerCase() : '';
+      if (currentFormattedKey) {
+        if ((currentFormattedKey.includes('api') && currentFormattedKey.includes('key')) || currentFormattedKey.includes('token') || currentFormattedKey.includes('secret')) {
+            if (typeof value === 'string' && value.length > 0) {
                 if (value.startsWith('ENV_') || value.includes('_API_KEY') || value.toUpperCase() === value || value.startsWith('${') || value.startsWith('{{')) {
                     return `Loaded from environment variable (e.g., ${value})`;
                 }
-                return `********${value.slice(-4)} (Likely loaded from environment)`;
+                if (value.length > 4) return `********${value.slice(-4)} (Masked)`;
+                return "**** (Masked)";
             }
         }
       }
       return value;
+    },
+    // Method to provide class for value styling based on type
+    getValueClass(value) {
+      if (typeof value === 'boolean') return 'config-value-boolean';
+      if (value === null) return 'config-value-null';
+      return '';
+    },
+    // Method to provide class for node title (key)
+    getNodeTitleClass(rawTitle) {
+      // Use the formatted key for class determination
+      const formattedTitle = this.formatKey(rawTitle);
+      if (formattedTitle === 'Id') {
+        // This will make any key that formats to "Id" prominent.
+        // This is a broad approach; more specific context (e.g. parent) would need prop drilling or event emitting.
+        return 'config-id-title';
+      }
+      return '';
     }
   },
 };
@@ -75,37 +97,85 @@ export default {
 
 <style scoped>
 .config-node-viewer {
-  padding-left: 10px;
-  margin-bottom: 6px;
-  line-height: 1.5;
+  padding-left: 10px; /* Base indentation for all nodes */
+  margin-bottom: 8px; /* Increased spacing between nodes */
+  line-height: 1.6; /* Slightly increased line height for readability */
 }
 
 .node-title {
-  color: #35495e; /* Dark blue-grey */
+  color: #35495e; /* Dark blue-grey for standard keys */
   font-weight: bold;
+  margin-right: 6px; /* Space between title/key and colon/value */
+  display: inline-block; /* Allows margin-bottom if it becomes block later */
 }
-.array-title { /* Specific title for root arrays if nodeTitle is not passed */
+
+/* Special styling for titles that act as headers for config items, specifically 'Id' */
+.node-title.config-id-title {
+  font-size: 1.1em; /* Make 'Id' fields slightly larger */
+  color: #0056b3; /* Darker, more prominent blue */
+  display: block; /* Make 'Id' title take its own line */
+  margin-top: 15px; /* Add significant space above a new 'Id' field, suggesting a new item */
+  margin-bottom: 6px; /* Space below the 'Id' title */
+  padding-bottom: 4px; /* Padding for the border */
+  border-bottom: 1px solid #e0e0e0; /* Separator line below 'Id' */
+}
+/* Ensure the first 'Id' in a list doesn't have excessive top margin */
+.config-object > ul > li:first-child > .config-node-viewer > .node-title.config-id-title,
+.config-array > ul > li:first-child > .config-node-viewer > .node-title.config-id-title {
+  margin-top: 5px; /* Reduced top margin for the very first 'Id' in a list */
+}
+
+
+.array-title { /* Styling for explicit "Array Items:" title */
     display: block;
-    margin-bottom: 4px;
+    margin-bottom: 5px; /* Space below "Array Items:" */
+    font-size: 1.05em;
+    color: #17a2b8; /* Info color for array titles */
 }
 
 .config-object ul,
 .config-array ul {
   list-style-type: none;
-  padding-left: 20px;
-  margin-top: 4px;
-  border-left: 2px dashed #bdc3c7; /* Light grey */
+  padding-left: 25px; /* Indentation for nested lists */
+  margin-top: 5px; /* Space above the list itself */
+  border-left: 2px solid #dfe4ea; /* Softer border color for visual grouping */
 }
 
 .config-object li,
 .config-array li {
-  margin-bottom: 5px;
+  margin-bottom: 6px; /* Spacing between individual list items */
+  padding-top: 3px; /* Padding within each list item */
 }
 
+/* Attempt to visually separate items in the main 'llm_configs' array */
+/* This targets list items that are direct children of a .config-array's ul.
+   It's a general approach for items in arrays.
+   If 'llm_configs' is the first array rendered, its items will get this style.
+*/
+.config-array > ul > li {
+  /* border-top: 1px solid #e9ecef; */ /* Removed this, as config-id-title provides better separation */
+  /* padding-top: 10px; */
+  /* margin-top: 5px; */ /* Using config-id-title's margin-top for separation */
+}
+/* .config-array > ul > li:first-child {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 3px;
+} */
+
+
 .config-value {
-  display: inline; /* Keep simple values on the same line as title */
-  margin-left: 8px;
-  color: #2c3e50; /* Slightly lighter than title */
-  word-break: break-all; /* Break long strings */
+  display: inline-block; /* Allows padding and better control than 'inline' */
+  margin-left: 5px; /* Space from the key/title */
+  color: #2c3e50; /* Standard value color */
+  word-break: break-all; /* Prevent long values from breaking layout */
+  vertical-align: top; /* Align with the top of the key if key is block/inline-block */
+}
+
+/* Specific styling for boolean and null values for better visual distinction */
+.config-value-boolean,
+.config-value-null {
+  font-style: italic;
+  color: #5a6268; /* Greyish color, stands out from regular string/number values */
 }
 </style>

--- a/jarules_electron_vue_ui/src/components/ConfigurationDisplay.vue
+++ b/jarules_electron_vue_ui/src/components/ConfigurationDisplay.vue
@@ -48,28 +48,40 @@ export default {
       try {
         const result = await window.api.getConfig();
 
-        if (result && result.error) {
+        // Check if the result itself is an error object (from main.js)
+        if (result && typeof result === 'object' && result.error) {
           console.error('Error from main process getConfig:', result.message, result.details);
-          this.error = `Failed to retrieve configuration from the backend. Details: ${result.message}${result.details ? ' - ' + result.details : ''}`;
+          const details = result.details || result.message || 'Unknown error from backend.';
+          this.error = `Error loading LLM configurations: Could not read 'llm_config.yaml'. File system or permission issue. Details: ${details}`;
           this.isLoading = false;
           return;
         }
 
+        // Expecting result to be a string (YAML content) if no error object was returned
         const yamlString = result;
-        if (yamlString && typeof yamlString === 'string') {
-          this.configurationContent = jsyaml.load(yamlString);
-        } else if (typeof yamlString === 'object' && yamlString !== null) {
-          this.configurationContent = yamlString; // Already parsed
-        } else if (!yamlString) { // Handles null or empty string from backend
-          this.error = 'No configuration content was returned from the backend. The configuration file might be empty or missing.';
-        }
-         else { // Fallback for unexpected types
+        if (typeof yamlString === 'string') {
+          if (yamlString.trim() === '') {
+            this.error = "No configuration content found. The 'llm_config.yaml' file might be empty.";
+            this.configurationContent = {}; // Set to empty object to avoid issues with ConfigNodeViewer expecting an object
+          } else {
+            this.configurationContent = jsyaml.load(yamlString); // This can throw YAMLException
+          }
+        } else if (yamlString === null || yamlString === undefined) { // Explicitly check for null/undefined if main.js could return that
+            this.error = "No configuration data was returned from the backend. The 'llm_config.yaml' file might be missing or inaccessible.";
+        } else { // Fallback for unexpected types if main.js changes its return contract
           this.error = 'Failed to load configuration: Invalid or unexpected format received from backend.';
           console.warn('Unexpected configuration format:', yamlString);
         }
-      } catch (err) { // Catches errors from jsyaml.load or other synchronous issues
-        console.error('Error parsing configuration YAML or other client-side issue:', err);
-        this.error = `Error processing configuration data: ${err.message}. Please check YAML syntax if the file was loaded.`;
+      } catch (err) { // Catches errors from jsyaml.load() or if window.api.getConfig() itself throws
+        console.error('Error in fetchConfiguration (parsing or IPC invoke):', err);
+        if (err.name === 'YAMLException') {
+          this.error = `Error parsing LLM configurations: The 'llm_config.yaml' file has invalid YAML syntax. Details: ${err.message}`;
+        } else if (err.message && err.message.includes("Invocation error")) { // Error from ipcRenderer.invoke if main handler throws unhandled
+            this.error = `Error fetching configuration from backend: ${err.message}. Check main process logs.`;
+        }
+        else {
+          this.error = `An unexpected error occurred while processing configuration: ${err.message}.`;
+        }
       }
       this.isLoading = false;
     }


### PR DESCRIPTION
Implements a read-only UI section in the Electron application to display the contents of the `llm_config.yaml` file. This enhances your visibility into the application's LLM configurations without allowing modifications through this interface.

Key changes:

- Enhanced `ConfigNodeViewer.vue`:
    - Improved styling for better clarity, readability, and visual hierarchy.
    - Added prominent display for configuration IDs to act as headers.
    - Implemented distinct styling for boolean and null values.
    - Improved visual spacing and indentation for nested structures.
    - Refined API key masking in the display.
- Improved `ConfigurationDisplay.vue`:
    - Enhanced error handling to provide more specific and user-friendly messages for various scenarios: - File read errors (missing file, permission issues). - Empty configuration file. - Invalid YAML syntax in the configuration file.
- Verified existing IPC mechanisms and component integration for fetching and displaying the configuration data.

The feature leverages existing components (`ConfigurationDisplay.vue`, `ConfigNodeViewer.vue`) and IPC channels, focusing on improving their presentation and robustness to meet the issue requirements. Code-based testing indicates the feature functions as expected.