### PR TITLE
Fix parameter passing in connector constructors

### DIFF
--- a/jarules_agent/connectors/claude_connector.py
+++ b/jarules_agent/connectors/claude_connector.py
@@ -266,7 +266,7 @@ if __name__ == '__main__':
     async def main():
         connector = None # Ensure connector is defined for finally block
         try:
-            connector = ClaudeConnector(config=sample_config)
+            connector = ClaudeConnector(**sample_config)
             logger.info("ClaudeConnector created.")
 
             available = await connector.check_availability() # Placeholder

--- a/jarules_agent/connectors/openrouter_connector.py
+++ b/jarules_agent/connectors/openrouter_connector.py
@@ -290,7 +290,7 @@ if __name__ == '__main__':
 
     async def main():
         try:
-            connector = OpenRouterConnector(config=sample_config)
+            connector = OpenRouterConnector(**sample_config)
             logger.info("Connector created.")
 
             # Test check_availability (placeholder)


### PR DESCRIPTION
Correct example usage for `ClaudeConnector` and `OpenRouterConnector` to prevent `TypeError`.

The example usage incorrectly passed a `config` dictionary as a single parameter, while the constructors expect individual keyword arguments via `**kwargs`.